### PR TITLE
Add session management endpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - run: docker compose up -d --build
+      - run: docker compose exec backend pytest -q
+      - run: docker compose logs
+  deploy:
+    needs: build-test
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.TARGET_SSH_KEY }}
+      - run: rsync -az --delete docker-compose.yml ubuntu@$HOST:~/sapid/
+        env:
+          HOST: ${{ secrets.HOST }}
+      - run: ssh ubuntu@$HOST 'cd sapid && docker compose pull && docker compose up -d --build'
+        env:
+          HOST: ${{ secrets.HOST }}
+      - run: ssh ubuntu@$HOST 'curl -f http://localhost:8001/health'
+        env:
+          HOST: ${{ secrets.HOST }}

--- a/.github/workflows/deploy-gpu.yml
+++ b/.github/workflows/deploy-gpu.yml
@@ -1,0 +1,56 @@
+name: Deploy & GPU Test
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # 1) Add SSH key
+      - name: Add SSH key
+        id: ssh
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.TARGET_SSH_KEY }}
+
+      # 2) Sync repo to server (~/sapid)
+      - name: Sync code to server
+        run: |
+          rsync -az --delete -e "ssh -o StrictHostKeyChecking=no" \
+            ./ ${{ secrets.TARGET_USER }}@${{ secrets.TARGET_HOST }}:~/sapid/
+
+      # 3) Remote build + up (GPU)
+      - name: Docker compose up
+        run: |
+          ssh ${{ secrets.TARGET_USER }}@${{ secrets.TARGET_HOST }} <<'EOF'
+            cd ~/sapid
+            docker compose pull
+            docker compose up -d --build
+          EOF
+
+      # 4) Wait for backend health
+      - name: Wait for backend
+        run: |
+          for i in {1..30}; do
+            if ssh ${{ secrets.TARGET_USER }}@${{ secrets.TARGET_HOST }} \
+              "curl -fs http://localhost:8001/health" ; then echo OK && exit 0; fi
+            sleep 5
+          done
+          exit 1
+
+      # 5) Run smoke tests (inside backend container)
+      - name: Run pytest
+        run: |
+          ssh ${{ secrets.TARGET_USER }}@${{ secrets.TARGET_HOST }} \
+            "cd ~/sapid && docker compose exec backend pytest -q"
+
+      # 6) Collect logs if tests fail
+      - name: Dump logs on failure
+        if: failure()
+        run: |
+          ssh ${{ secrets.TARGET_USER }}@${{ secrets.TARGET_HOST }} \
+            "cd ~/sapid && docker compose logs --tail=200"

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,3 @@
+[alembic]
+script_location = backend/alembic
+sqlalchemy.url = 

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,0 +1,33 @@
+from logging.config import fileConfig
+from sqlmodel import SQLModel
+
+from alembic import context
+
+from core.db import engine
+
+config = context.config
+if config.config_file_name:
+    fileConfig(config.config_file_name)
+
+target_metadata = SQLModel.metadata
+
+def run_migrations_offline() -> None:
+    context.configure(
+        url=str(engine.url),
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+def run_migrations_online() -> None:
+    with engine.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/alembic/script.py.mako
+++ b/backend/alembic/script.py.mako
@@ -1,0 +1,16 @@
+<%text># Template used by Alembic to generate migration scripts</%text>
+"""${message}"""
+
+revision = '${up_revision}'
+down_revision = ${down_revision if down_revision else None}
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+
+def upgrade() -> None:
+    pass
+
+def downgrade() -> None:
+    pass

--- a/backend/alembic/versions/0001_initial.py
+++ b/backend/alembic/versions/0001_initial.py
@@ -1,0 +1,39 @@
+"""initial tables"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    op.create_table(
+        "chat_session",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+    )
+    op.create_table(
+        "conversation",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("session_id", sa.Integer(), sa.ForeignKey("chat_session.id"), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+    )
+    op.create_table(
+        "chat_message",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("conversation_id", sa.Integer(), sa.ForeignKey("conversation.id"), nullable=False),
+        sa.Column("sender", sa.String(), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column("llm_intent", sa.String(), nullable=True),
+        sa.Column("confidence", sa.Float(), nullable=True),
+        sa.Column("timestamp", sa.DateTime(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("chat_message")
+    op.drop_table("conversation")
+    op.drop_table("chat_session")

--- a/backend/alembic/versions/0002_document.py
+++ b/backend/alembic/versions/0002_document.py
@@ -1,0 +1,25 @@
+"""add document table"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0002"
+down_revision = "0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "document",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("type", sa.String(), nullable=False),
+        sa.Column("size", sa.Integer(), nullable=False),
+        sa.Column("uploaded_at", sa.DateTime(), nullable=False),
+        sa.Column("session_id", sa.Integer(), sa.ForeignKey("chat_session.id"), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("document")

--- a/backend/alembic/versions/0003_form_submission.py
+++ b/backend/alembic/versions/0003_form_submission.py
@@ -1,0 +1,25 @@
+"""add form_submission table"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0003"
+down_revision = "0002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "form_submission",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("form_id", sa.String(), nullable=False),
+        sa.Column("session_id", sa.Integer(), sa.ForeignKey("chat_session.id"), nullable=False),
+        sa.Column("data", sa.Text(), nullable=False),
+        sa.Column("submitted_at", sa.DateTime(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("form_submission")
+

--- a/backend/api/__init__.py
+++ b/backend/api/__init__.py
@@ -1,0 +1,3 @@
+from fastapi import APIRouter
+
+router = APIRouter()

--- a/backend/api/chat.py
+++ b/backend/api/chat.py
@@ -1,0 +1,59 @@
+import os
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from ..core.llm import LLM
+from ..core.rag import RAG
+from ..core import db
+from ..external.incident_api import IncidentAPI
+
+ollama_url = os.getenv("OLLAMA_URL", "http://localhost:11434")
+chat_model = os.getenv("OLLAMA_CHAT_MODEL", "llama3")
+embed_model = os.getenv("OLLAMA_EMBED_MODEL", "nomic-embed-text")
+chroma_url = os.getenv("CHROMA_URL", "http://localhost:8000")
+
+llm = LLM(ollama_url, chat_model, embed_model)
+rag = RAG(llm, chroma_url)
+incident_api = IncidentAPI()
+
+router = APIRouter()
+
+
+class ChatIn(BaseModel):
+    session_id: int | None = None
+    conversation_id: int | None = None
+    user: str
+    message: str
+
+
+def render_sources(sources: list[dict]) -> str:
+    links = [
+        f"[p{src.get('page')} \u00b6{src.get('chunk_id')}](#/pdf/{src.get('doc_id')}?p={src.get('page')}&c={src.get('chunk_id')})"
+        for src in sources
+    ]
+    return "\n".join(links)
+
+
+@router.post("/")
+async def chat_endpoint(payload: ChatIn) -> dict:
+    session = db.get_or_create_session(payload.session_id)
+    conversation = None
+    if payload.conversation_id is not None:
+        conversation = db.get_conversation(payload.conversation_id)
+    if conversation is None:
+        conversation = db.create_conversation(session.id)
+    intent, conf = llm.classify_intent(payload.message)
+    rag_ans, sources = rag.query(payload.message, f"temp_{session.id}", 5)
+    if intent in {"incident_report", "maintenance_query"} and conf > 0.6:
+        incident_api.collect(session.id, payload.message, intent)
+    full_answer = rag_ans
+    if sources:
+        full_answer += "\n" + render_sources(sources)
+    db.add_message(
+        conversation_id=conversation.id,
+        sender=payload.user,
+        content=payload.message,
+        llm_intent=intent,
+        confidence=conf,
+    )
+    return {"answer": full_answer, "intent": intent, "sources": sources}

--- a/backend/api/conversations.py
+++ b/backend/api/conversations.py
@@ -1,0 +1,49 @@
+from fastapi import APIRouter, Response
+from pydantic import BaseModel
+
+from ..core import db
+
+router = APIRouter()
+
+
+class ConversationIn(BaseModel):
+    session_id: int
+
+
+@router.post("/")
+def create_conversation(payload: ConversationIn) -> dict:
+    conv = db.create_conversation(payload.session_id)
+    return {"id": conv.id, "session_id": conv.session_id, "created_at": conv.created_at}
+
+
+@router.get("/")
+def list_conversations(session_id: int | None = None) -> list[dict]:
+    conversations = db.list_conversations(session_id)
+    return [
+        {"id": c.id, "session_id": c.session_id, "created_at": c.created_at}
+        for c in conversations
+    ]
+
+
+@router.delete("/{conversation_id}", status_code=204)
+def delete_conversation(conversation_id: int) -> Response:
+    db.delete_conversation(conversation_id)
+    return Response(status_code=204)
+
+
+@router.get("/{conversation_id}/messages")
+def get_messages(conversation_id: int) -> list[dict]:
+    messages = db.get_messages(conversation_id)
+    return [
+        {
+            "id": m.id,
+            "conversation_id": m.conversation_id,
+            "sender": m.sender,
+            "content": m.content,
+            "llm_intent": m.llm_intent,
+            "confidence": m.confidence,
+            "timestamp": m.timestamp,
+        }
+        for m in messages
+    ]
+

--- a/backend/api/forms.py
+++ b/backend/api/forms.py
@@ -1,0 +1,24 @@
+import json
+from pydantic import BaseModel
+from fastapi import APIRouter
+
+from ..core import db
+
+router = APIRouter()
+
+
+class FormIn(BaseModel):
+    form_id: str
+    data: dict
+    session_id: int
+
+
+@router.post("/")
+def submit_form(payload: FormIn) -> dict:
+    db.add_form_submission(
+        payload.form_id,
+        payload.session_id,
+        json.dumps(payload.data),
+    )
+    return {"status": "ok"}
+

--- a/backend/api/sessions.py
+++ b/backend/api/sessions.py
@@ -1,0 +1,18 @@
+from datetime import datetime
+from fastapi import APIRouter, Response
+
+from ..core import db
+
+router = APIRouter()
+
+
+@router.post("/")
+def create_session() -> dict:
+    session = db.create_session()
+    return {"id": session.id, "created_at": session.created_at}
+
+
+@router.delete("/{session_id}", status_code=204)
+def delete_session(session_id: int) -> Response:
+    db.delete_session(session_id)
+    return Response(status_code=204)

--- a/backend/api/upload.py
+++ b/backend/api/upload.py
@@ -1,0 +1,96 @@
+import os
+import tempfile
+
+from fastapi import APIRouter, UploadFile, HTTPException, Response
+
+from ..core.llm import LLM
+from ..core.rag import RAG
+from ..core import db
+
+ollama_url = os.getenv("OLLAMA_URL", "http://localhost:11434")
+chat_model = os.getenv("OLLAMA_CHAT_MODEL", "llama3")
+embed_model = os.getenv("OLLAMA_EMBED_MODEL", "nomic-embed-text")
+chroma_url = os.getenv("CHROMA_URL", "http://localhost:8000")
+
+rag = RAG(LLM(ollama_url, chat_model, embed_model), chroma_url)
+
+router = APIRouter()
+
+@router.post("/")
+async def upload(file: UploadFile, type: str, session_id: int | None = None) -> dict:
+    data = await file.read()
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as tmp:
+        tmp.write(data)
+        path = tmp.name
+
+    if type == "global":
+        collection = "global"
+        is_temp = False
+    else:
+        if session_id is None:
+            raise HTTPException(status_code=400, detail="session_id required for temporary documents")
+        collection = f"temp_{session_id}"
+        is_temp = True
+
+    doc = db.add_document(file.filename, type, len(data), session_id)
+    rag.embed_pdf(path, collection, is_temp, doc_id=str(doc.id))
+    return {"id": doc.id, "collection": collection}
+
+@router.post("/global")
+async def upload_global(file: UploadFile) -> dict:
+    """Upload a PDF to the global knowledge base."""
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as tmp:
+        tmp.write(await file.read())
+        path = tmp.name
+
+    rag.embed_pdf(path, "global", is_temp=False)
+    return {"status": "ok", "collection": "global"}
+
+
+@router.post("/temp/{session_id}")
+async def upload_temp(session_id: int, file: UploadFile) -> dict:
+    """Upload a PDF to a session-scoped temporary collection."""
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as tmp:
+        tmp.write(await file.read())
+        path = tmp.name
+
+    collection = f"temp_{session_id}"
+    rag.embed_pdf(path, collection, is_temp=True)
+    return {"status": "ok", "collection": collection}
+
+
+@router.get("/documents")
+def list_docs(session_id: int | None = None) -> list[dict]:
+    docs = db.list_documents(session_id)
+    return [
+        {
+            "id": d.id,
+            "name": d.name,
+            "type": d.type,
+            "size": d.size,
+            "uploaded_at": d.uploaded_at,
+            "session_id": d.session_id,
+        }
+        for d in docs
+    ]
+
+
+@router.get("/documents/{doc_id}")
+def get_doc(doc_id: int):
+    doc = db.get_document(doc_id)
+    if not doc:
+        raise HTTPException(status_code=404, detail="Not found")
+    return {
+        "id": doc.id,
+        "name": doc.name,
+        "type": doc.type,
+        "size": doc.size,
+        "uploaded_at": doc.uploaded_at,
+        "session_id": doc.session_id,
+    }
+
+
+@router.delete("/documents/{doc_id}", status_code=204)
+def delete_doc(doc_id: int) -> Response:
+    db.delete_document(doc_id)
+    return Response(status_code=204)

--- a/backend/core/__init__.py
+++ b/backend/core/__init__.py
@@ -1,0 +1,1 @@
+# Core package initialization

--- a/backend/core/db.py
+++ b/backend/core/db.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from datetime import datetime
+from typing import Iterator, Optional
+
+from sqlmodel import Field, SQLModel, Session, create_engine, delete, select
+
+DATABASE_URL = os.getenv("POSTGRES_URL", "sqlite:///./local.db")
+
+engine = create_engine(DATABASE_URL, echo=False)
+
+
+class ChatSession(SQLModel, table=True):
+    __tablename__ = "chat_session"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    created_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+
+
+class Conversation(SQLModel, table=True):
+    __tablename__ = "conversation"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    session_id: int = Field(foreign_key="chat_session.id")
+    created_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+
+
+class ChatMessage(SQLModel, table=True):
+    __tablename__ = "chat_message"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    conversation_id: int = Field(foreign_key="conversation.id")
+    sender: str
+    content: str
+    llm_intent: Optional[str] = None
+    confidence: Optional[float] = None
+    timestamp: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+
+
+class Document(SQLModel, table=True):
+    __tablename__ = "document"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str
+    type: str
+    size: int
+    uploaded_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+    session_id: Optional[int] = Field(default=None, foreign_key="chat_session.id")
+
+
+class FormSubmission(SQLModel, table=True):
+    __tablename__ = "form_submission"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    form_id: str
+    session_id: int = Field(foreign_key="chat_session.id")
+    data: str
+    submitted_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+
+
+@contextmanager
+def get_session() -> Iterator[Session]:
+    with Session(engine) as session:
+        yield session
+
+
+def get_or_create_session(session_id: Optional[int]) -> ChatSession:
+    """Return an existing ChatSession or create a new one."""
+    with get_session() as session:
+        if session_id is not None:
+            existing = session.get(ChatSession, session_id)
+            if existing:
+                return existing
+
+        new_session = ChatSession()
+        session.add(new_session)
+        session.commit()
+        session.refresh(new_session)
+        return new_session
+
+
+def create_session() -> ChatSession:
+    """Explicitly create a new chat session."""
+    with get_session() as session:
+        new_session = ChatSession()
+        session.add(new_session)
+        session.commit()
+        session.refresh(new_session)
+        return new_session
+
+
+def delete_session(session_id: int) -> None:
+    """Delete a chat session and its messages."""
+    with get_session() as session:
+        conv_ids = [c.id for c in session.exec(select(Conversation.id).where(Conversation.session_id == session_id))]
+        if conv_ids:
+            session.exec(delete(ChatMessage).where(ChatMessage.conversation_id.in_(conv_ids)))
+            session.exec(delete(Conversation).where(Conversation.id.in_(conv_ids)))
+        session.exec(delete(ChatSession).where(ChatSession.id == session_id))
+        session.commit()
+
+
+def create_conversation(session_id: int) -> Conversation:
+    """Create a new conversation for a session."""
+    with get_session() as session:
+        conv = Conversation(session_id=session_id)
+        session.add(conv)
+        session.commit()
+        session.refresh(conv)
+        return conv
+
+
+def list_conversations(session_id: Optional[int] = None) -> list[Conversation]:
+    with get_session() as session:
+        stmt = select(Conversation)
+        if session_id is not None:
+            stmt = stmt.where(Conversation.session_id == session_id)
+        return session.exec(stmt).all()
+
+
+def delete_conversation(conversation_id: int) -> None:
+    with get_session() as session:
+        session.exec(delete(ChatMessage).where(ChatMessage.conversation_id == conversation_id))
+        session.exec(delete(Conversation).where(Conversation.id == conversation_id))
+        session.commit()
+
+
+def get_conversation(conversation_id: int) -> Conversation | None:
+    with get_session() as session:
+        return session.get(Conversation, conversation_id)
+
+
+def get_messages(conversation_id: int) -> list[ChatMessage]:
+    with get_session() as session:
+        stmt = select(ChatMessage).where(ChatMessage.conversation_id == conversation_id)
+        return session.exec(stmt).all()
+
+
+def add_message(
+    conversation_id: int,
+    sender: str,
+    content: str,
+    llm_intent: Optional[str] = None,
+    confidence: Optional[float] = None,
+) -> ChatMessage:
+    """Persist a chat message."""
+    with get_session() as session:
+        msg = ChatMessage(
+            conversation_id=conversation_id,
+            sender=sender,
+            content=content,
+            llm_intent=llm_intent,
+            confidence=confidence,
+        )
+        session.add(msg)
+        session.commit()
+        session.refresh(msg)
+        return msg
+
+
+def add_document(name: str, type: str, size: int, session_id: Optional[int]) -> Document:
+    with get_session() as session:
+        doc = Document(name=name, type=type, size=size, session_id=session_id)
+        session.add(doc)
+        session.commit()
+        session.refresh(doc)
+        return doc
+
+
+def list_documents(session_id: Optional[int] = None) -> list[Document]:
+    with get_session() as session:
+        stmt = select(Document)
+        if session_id is not None:
+            stmt = stmt.where(Document.session_id == session_id)
+        return session.exec(stmt).all()
+
+
+def get_document(doc_id: int) -> Document | None:
+    with get_session() as session:
+        return session.get(Document, doc_id)
+
+
+def delete_document(doc_id: int) -> None:
+    with get_session() as session:
+        session.exec(delete(Document).where(Document.id == doc_id))
+        session.commit()
+
+
+def add_form_submission(form_id: str, session_id: int, data: str) -> FormSubmission:
+    """Store a submitted form."""
+    with get_session() as session:
+        sub = FormSubmission(form_id=form_id, session_id=session_id, data=data)
+        session.add(sub)
+        session.commit()
+        session.refresh(sub)
+        return sub
+

--- a/backend/core/llm.py
+++ b/backend/core/llm.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+from typing import List, Tuple
+
+import requests
+
+
+class LLM:
+    """Simple client for interacting with an LLM service."""
+
+    def __init__(self, base_url: str, chat_model: str, embed_model: str) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.chat_model = chat_model
+        self.embed_model = embed_model
+
+    def embed(self, text: str) -> List[float]:
+        """Return the embedding vector for *text* using the embed model."""
+        url = f"{self.base_url}/api/embeddings"
+        resp = requests.post(url, json={"model": self.embed_model, "prompt": text})
+        resp.raise_for_status()
+        data = resp.json()
+        if "embedding" in data:
+            return data["embedding"]
+        # Fallback to OpenAI style {data:[{embedding:[]}]}
+        return data.get("data", [{}])[0].get("embedding", [])
+
+    def chat(self, messages: List[dict]) -> str:
+        """Chat with the model using OpenAI formatted messages."""
+        url = f"{self.base_url}/api/chat"
+        payload = {"model": self.chat_model, "messages": messages}
+        resp = requests.post(url, json=payload)
+        resp.raise_for_status()
+        data = resp.json()
+        if isinstance(data, dict):
+            if "message" in data and isinstance(data["message"], dict):
+                return data["message"].get("content", "")
+            if "choices" in data:
+                return data["choices"][0]["message"]["content"]
+        return str(data)
+
+    def classify_intent(self, text: str) -> Tuple[str, float]:
+        """Classify the intent of *text* using the chat model."""
+        system = (
+            "You are an intent classifier. Respond with JSON of the form "
+            "{\"intent\":<intent>,\"confidence\":<score>} where confidence is "
+            "between 0 and 1."
+        )
+        messages = [
+            {"role": "system", "content": system},
+            {"role": "user", "content": text},
+        ]
+        response = self.chat(messages)
+        try:
+            result = json.loads(response)
+            return result.get("intent", ""), float(result.get("confidence", 0))
+        except Exception:
+            return response.strip(), 0.0

--- a/backend/core/rag.py
+++ b/backend/core/rag.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import os
+from typing import List, Tuple
+from uuid import uuid4
+from urllib.parse import urlparse
+
+import chromadb
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from pypdf import PdfReader
+
+from .llm import LLM
+
+
+class RAG:
+    """Minimal helper around a Chroma database and an LLM."""
+
+    def __init__(self, llm: LLM, chroma_url: str) -> None:
+        self.llm = llm
+        parsed = urlparse(chroma_url)
+        host = parsed.hostname or "localhost"
+        port = parsed.port or 8000
+        self.client = chromadb.HttpClient(host=host, port=port)
+
+    def _collection(self, name: str):
+        return self.client.get_or_create_collection(name)
+
+    def embed_pdf(
+        self, path: str, collection_name: str, is_temp: bool, doc_id: str | None = None
+    ) -> None:
+        """Embed the given PDF into the specified Chroma collection."""
+
+        reader = PdfReader(path)
+        splitter = RecursiveCharacterTextSplitter(chunk_size=500, chunk_overlap=50)
+        collection = self._collection(collection_name)
+        doc_identifier = doc_id or os.path.basename(path)
+
+        for page_number, page in enumerate(reader.pages):
+            text = page.extract_text() or ""
+            chunks = splitter.split_text(text)
+            for chunk_id, chunk in enumerate(chunks):
+                embedding = self.llm.embed(chunk)
+                metadata = {
+                    "doc_id": doc_identifier,
+                    "page": page_number,
+                    "chunk_id": chunk_id,
+                    "text": chunk,
+                }
+                collection.add(
+                    ids=[str(uuid4())],
+                    embeddings=[embedding],
+                    documents=[chunk],
+                    metadatas=[metadata],
+                )
+
+        if is_temp:
+            os.remove(path)
+
+    def query(
+        self, question: str, temp_collection: str | None, top_k: int = 5
+    ) -> Tuple[str, List[dict]]:
+        """Query the RAG system and return the answer and source metadata."""
+
+        collections = [self._collection("global")]
+        if temp_collection:
+            collections.append(self._collection(temp_collection))
+
+        docs: List[str] = []
+        sources: List[dict] = []
+        for coll in collections:
+            res = coll.query(
+                query_texts=[question],
+                n_results=top_k,
+                include=["documents", "metadatas"],
+            )
+            docs.extend(res.get("documents", [[]])[0])
+            sources.extend(res.get("metadatas", [[]])[0])
+
+        context = "\n".join(docs)
+        messages = [
+            {
+                "role": "system",
+                "content": "Answer the question using the provided context.",
+            },
+            {
+                "role": "user",
+                "content": f"Context:\n{context}\n\nQuestion: {question}",
+            },
+        ]
+        answer = self.llm.chat(messages)
+        return answer, sources

--- a/backend/docker/Dockerfile
+++ b/backend/docker/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/backend/external/incident_api.py
+++ b/backend/external/incident_api.py
@@ -1,0 +1,10 @@
+class IncidentAPI:
+    """Stub for interacting with an external incident management API."""
+
+    def get_incidents(self):
+        return []
+
+    def collect(self, session_id: int, text: str, intent: str) -> None:
+        """Send incident-related text to the external system."""
+        # This is a stub for future integration.
+        return None

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,18 @@
+from fastapi import FastAPI
+
+from api import chat, upload
+from api import sessions
+from api import conversations
+from api import forms
+
+app = FastAPI()
+
+app.include_router(chat.router, prefix="/chat")
+app.include_router(upload.router, prefix="/upload")
+app.include_router(sessions.router, prefix="/sessions")
+app.include_router(conversations.router, prefix="/conversations")
+app.include_router(forms.router, prefix="/forms")
+
+@app.get("/health")
+def health() -> dict:
+    return {"status": "ok"}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,10 @@
+fastapi
+uvicorn
+sqlmodel
+alembic
+psycopg2-binary
+requests
+pypdf
+chromadb
+langchain
+httpx

--- a/backend/tests/smoke_gpu.py
+++ b/backend/tests/smoke_gpu.py
@@ -1,0 +1,47 @@
+from io import BytesIO
+
+import requests
+from pypdf import PdfWriter
+from sqlmodel import select
+
+from backend.core import db
+
+
+def test_smoke_gpu():
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    buf = BytesIO()
+    writer.write(buf)
+    buf.seek(0)
+
+    resp = requests.post(
+        "http://localhost:8001/upload/global",
+        files={"file": ("dummy.pdf", buf, "application/pdf")},
+    )
+    assert resp.status_code == 200
+
+    sess_resp = requests.post("http://localhost:8001/sessions")
+    assert sess_resp.status_code == 200
+    session_id = sess_resp.json()["id"]
+
+    payload = {
+        "session_id": session_id,
+        "user": "tester",
+        "message": "What is in the doc?",
+    }
+    conv_resp = requests.post(
+        "http://localhost:8001/conversations",
+        json={"session_id": session_id},
+    )
+    assert conv_resp.status_code == 200
+    conv_id = conv_resp.json()["id"]
+    payload["conversation_id"] = conv_id
+    resp = requests.post("http://localhost:8001/chat/", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "(#/pdf/" in data.get("answer", "")
+    assert data.get("intent") in {"general", "document_query"}
+
+    with db.get_session() as session:
+        msgs = session.exec(select(db.ChatMessage)).all()
+        assert len(msgs) >= 1

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -1,0 +1,73 @@
+import os
+from pathlib import Path
+import sys
+from httpx import AsyncClient, ASGITransport
+from sqlmodel import select
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+
+@pytest.mark.asyncio
+async def test_chat_flow(tmp_path, monkeypatch):
+    os.environ['POSTGRES_URL'] = f"sqlite:///{tmp_path}/test.db"
+
+    import backend.core.rag as rag_module
+
+    class DummyCollection:
+        def add(self, *args, **kwargs):
+            pass
+
+        def query(self, *args, **kwargs):
+            return {"documents": [[]], "metadatas": [[]]}
+
+    class DummyClient:
+        def get_or_create_collection(self, name):
+            return DummyCollection()
+
+    monkeypatch.setattr(rag_module, "chromadb", type("x", (), {"HttpClient": lambda *a, **k: DummyClient()})())
+
+    import backend.core.db as db
+    import backend.api as backend_api
+    import backend.api.chat as chat
+    import backend.api.upload as upload
+    sys.modules['api'] = backend_api
+    import backend.main as main
+
+    db.SQLModel.metadata.create_all(db.engine)
+
+    monkeypatch.setattr(upload.rag, 'embed_pdf', lambda *args, **kwargs: None)
+    monkeypatch.setattr(chat.rag, 'query', lambda *args, **kwargs: (
+        'the answer', [{'doc_id': 'doc1', 'page': 0, 'chunk_id': 1}]
+    ))
+    monkeypatch.setattr(chat.llm, 'classify_intent', lambda text: ('general', 0.7))
+    collect_calls = []
+    import backend.external.incident_api as incident_mod
+    monkeypatch.setattr(incident_mod.IncidentAPI, 'collect', lambda self, *a, **kw: collect_calls.append(a))
+
+    session = db.get_or_create_session(None)
+    conv = db.create_conversation(session.id)
+
+    pdf_path = 'frontend/public/demo/financial-report.pdf'
+
+    transport = ASGITransport(app=main.app)
+    async with AsyncClient(transport=transport, base_url='http://test') as client:
+        with open(pdf_path, 'rb') as fh:
+            resp = await client.post(f'/upload/temp/{session.id}', files={'file': ('test.pdf', fh, 'application/pdf')})
+            assert resp.status_code == 200
+        payload = {
+            'session_id': session.id,
+            'conversation_id': conv.id,
+            'user': 'alice',
+            'message': 'hello'
+        }
+        resp = await client.post('/chat/', json=payload)
+        assert resp.status_code == 200
+        data = resp.json()
+
+    assert '(#/pdf/' in data['answer']
+
+    with db.get_session() as s:
+        msgs = s.exec(select(db.ChatMessage)).all()
+        assert len(msgs) == 1
+        assert msgs[0].content == 'hello'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,106 @@
+version: '3.8'
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: sapid
+      POSTGRES_PASSWORD: sapid
+      POSTGRES_DB: sapid
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  chroma:
+    image: chroma/chroma:latest
+    environment:
+      IS_PERSISTENT: "TRUE"
+    volumes:
+      - chroma_data:/chroma
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://chroma:8000/heartbeat"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  ollama:
+    image: ollama/ollama:latest
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama_models:/root/.ollama
+    command: ["ollama", "serve"]
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: ["gpu"]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://ollama:11434/api/tags"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  backend:
+    build: backend/docker
+    depends_on:
+      - postgres
+      - chroma
+      - ollama
+    environment:
+      POSTGRES_URL: postgresql://sapid:sapid@postgres:5432/sapid
+      CHROMA_URL: http://chroma:8000
+      OLLAMA_URL: http://ollama:11434
+      OLLAMA_CHAT_MODEL: tinyllama:latest
+      OLLAMA_EMBED_MODEL: nomic-embed-text
+    ports:
+      - "8001:8001"
+    volumes:
+      - ./backend:/app
+      - ./frontend:/frontend
+
+  nginx:
+    image: nginx:alpine
+    depends_on:
+      - frontend-build
+    volumes:
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./frontend/dist:/usr/share/nginx/html:ro
+    ports:
+      - "3000:80"
+
+  frontend-build:
+    image: node:20-alpine
+    working_dir: /workspace
+    volumes:
+      - ./frontend:/workspace
+    command: ["sh", "-c", "npm ci && npm run build"]
+    profiles:
+      - build
+
+  whisper:
+    build:
+      context: ./docker/voice
+      dockerfile: Dockerfile.whisper
+    ports:
+      - "9000:9000"
+    profiles:
+      - voice
+
+  tts:
+    build:
+      context: ./docker/voice
+      dockerfile: Dockerfile.tts
+    ports:
+      - "9001:9001"
+    profiles:
+      - voice
+
+volumes:
+  postgres_data: {}
+  chroma_data: {}
+  ollama_models: {}

--- a/docker/voice/Dockerfile.tts
+++ b/docker/voice/Dockerfile.tts
@@ -1,0 +1,2 @@
+FROM ghcr.io/coqui-ai/tts:latest
+CMD ["tts_server"]

--- a/docker/voice/Dockerfile.whisper
+++ b/docker/voice/Dockerfile.whisper
@@ -1,0 +1,2 @@
+FROM ghcr.io/ggerganov/whisper.cpp:latest
+CMD ["serve"]

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,50 @@
+export interface Source {
+  doc_id: string;
+  page: number;
+  chunk_id: number;
+  text: string;
+}
+
+export interface ChatResponse {
+  answer: string;
+  intent: string;
+  sources: Source[];
+}
+
+const baseURL = import.meta.env.VITE_API_BASE || '/api';
+
+export async function chat(sessionId: string, text: string): Promise<ChatResponse> {
+  const res = await fetch(`${baseURL}/chat`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ session_id: sessionId, user: 'user', message: text }),
+  });
+  if (!res.ok) {
+    throw new Error('Failed to send chat message');
+  }
+  return res.json();
+}
+
+export async function uploadTemp(sessionId: string, f: File): Promise<void> {
+  const form = new FormData();
+  form.append('file', f);
+  const res = await fetch(`${baseURL}/upload/temp/${sessionId}`, {
+    method: 'POST',
+    body: form,
+  });
+  if (!res.ok) {
+    throw new Error('Failed to upload file');
+  }
+}
+
+export async function uploadGlobal(f: File): Promise<void> {
+  const form = new FormData();
+  form.append('file', f);
+  const res = await fetch(`${baseURL}/upload/global`, {
+    method: 'POST',
+    body: form,
+  });
+  if (!res.ok) {
+    throw new Error('Failed to upload file');
+  }
+}


### PR DESCRIPTION
## Summary
- implement chat session creation and deletion in the DB layer
- expose POST `/sessions` and DELETE `/sessions/{session_id}` endpoints
- wire new session router in FastAPI app
- add conversation support with dedicated models and routes
- implement document management endpoints and DB model
- add new form submission endpoint and database model

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`
- `npm run lint` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6846efed5f8c832fb5c9e0a22e73d4e7