### PR TITLE
Add nginx default config

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,18 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    location /api/ {
+        proxy_pass http://backend:8001/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+        root /usr/share/nginx/html;
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Summary
- create `nginx/default.conf` for nginx service in docker compose
- proxy `/api` to backend and serve frontend build directory

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847bbd18df8832fbd96eafc51369b2c