### PR TITLE
Align document API path with backend

### DIFF
--- a/frontend/src/api/apiService.ts
+++ b/frontend/src/api/apiService.ts
@@ -125,7 +125,7 @@ class ApiService {
       throw new Error('No active session');
     }
 
-    const response = await fetch(`${API_BASE_URL}/documents?session_id=${this.sessionId}`);
+    const response = await fetch(`${API_BASE_URL}/upload/documents?session_id=${this.sessionId}`);
     
     if (!response.ok) {
       throw new Error('Failed to fetch documents');
@@ -135,7 +135,7 @@ class ApiService {
   }
 
   async getDocument(docId: string): Promise<Document> {
-    const response = await fetch(`${API_BASE_URL}/documents/${docId}`);
+    const response = await fetch(`${API_BASE_URL}/upload/documents/${docId}`);
     
     if (!response.ok) {
       throw new Error('Failed to fetch document');
@@ -145,7 +145,7 @@ class ApiService {
   }
 
   async deleteDocument(docId: string): Promise<void> {
-    const response = await fetch(`${API_BASE_URL}/documents/${docId}`, {
+    const response = await fetch(`${API_BASE_URL}/upload/documents/${docId}`, {
       method: 'DELETE',
     });
 

--- a/frontend/src/api/endpoints.md
+++ b/frontend/src/api/endpoints.md
@@ -54,12 +54,12 @@ Cleans up session and associated temporary documents.
   "type": "permanent",
   "size": 1024000,
   "uploaded_at": "2024-01-20T10:00:00Z",
-  "url": "/documents/doc_uuid/view"
+  "url": "/upload/documents/doc_uuid/view"
 }
 ```
 
 ### Get Documents
-**GET** `/documents?session_id={session_id}`
+**GET** `/upload/documents?session_id={session_id}`
 
 Returns all documents for the session.
 
@@ -72,18 +72,18 @@ Returns all documents for the session.
     "type": "permanent",
     "size": 1024000,
     "uploaded_at": "2024-01-20T10:00:00Z",
-    "url": "/documents/doc_uuid/view"
+    "url": "/upload/documents/doc_uuid/view"
   }
 ]
 ```
 
 ### Get Document
-**GET** `/documents/{doc_id}`
+**GET** `/upload/documents/{doc_id}`
 
 Returns document metadata and content URL.
 
 ### Delete Document
-**DELETE** `/documents/{doc_id}`
+**DELETE** `/upload/documents/{doc_id}`
 
 Deletes the specified document.
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -59,7 +59,7 @@ class ApiService {
       throw new Error('No active session');
     }
 
-    const response = await fetch(`${API_BASE_URL}/documents?session_id=${this.sessionId}`);
+    const response = await fetch(`${API_BASE_URL}/upload/documents?session_id=${this.sessionId}`);
     
     if (!response.ok) {
       throw new Error('Failed to fetch documents');
@@ -69,7 +69,7 @@ class ApiService {
   }
 
   async getDocument(docId: string): Promise<Document> {
-    const response = await fetch(`${API_BASE_URL}/documents/${docId}`);
+    const response = await fetch(`${API_BASE_URL}/upload/documents/${docId}`);
     
     if (!response.ok) {
       throw new Error('Failed to fetch document');
@@ -79,7 +79,7 @@ class ApiService {
   }
 
   async deleteDocument(docId: string): Promise<void> {
-    const response = await fetch(`${API_BASE_URL}/documents/${docId}`, {
+    const response = await fetch(`${API_BASE_URL}/upload/documents/${docId}`, {
       method: 'DELETE',
     });
 


### PR DESCRIPTION
## Summary
- point frontend document API calls to `/upload/documents`
- reflect the prefix in API reference docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847bda6fa18832fa2b179df8e356162