### PR TITLE
Fix Docker build paths and API URLs

### DIFF
--- a/backend/docker/Dockerfile
+++ b/backend/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12-slim
 WORKDIR /app
-COPY requirements.txt .
+COPY ./requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,9 @@ services:
       retries: 5
 
   backend:
-    build: backend/docker
+    build:
+      context: ./backend
+      dockerfile: docker/Dockerfile
     depends_on:
       - postgres
       - chroma

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -20,7 +20,7 @@ npm run dev
 
 ## Backend Integration
 
-The application expects a backend server running on `localhost:8000` with the following API endpoints. See `src/api/endpoints.md` for detailed API specifications.
+The application expects a backend server accessible at the `/api` path (for example via Nginx proxying to `localhost:8001`). See `src/api/endpoints.md` for detailed API specifications.
 
 ## Demo Mode
 

--- a/frontend/src/api/apiService.ts
+++ b/frontend/src/api/apiService.ts
@@ -1,6 +1,6 @@
 import { Document, Message, Session, Conversation, StreamChunk } from '../types';
 
-const API_BASE_URL = 'http://localhost:8000';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 
 class ApiService {
   private sessionId: string | null = null;

--- a/frontend/src/api/endpoints.md
+++ b/frontend/src/api/endpoints.md
@@ -4,7 +4,7 @@ This document defines the complete API specification for SAPID backend integrati
 
 ## Base URL
 ```
-http://localhost:8000
+/api
 ```
 
 ## Authentication

--- a/frontend/src/components/Layout/SettingsTab.tsx
+++ b/frontend/src/components/Layout/SettingsTab.tsx
@@ -2,6 +2,8 @@ import React, { useState, useEffect } from 'react';
 import { Moon, Sun, Globe, TestTube, Activity, WifiOff, RefreshCw, Shield, User } from 'lucide-react';
 import { AppSettings } from '../../types';
 
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
+
 interface SettingsTabProps {
   settings: AppSettings;
   onSettingsChange: (settings: AppSettings) => void;
@@ -13,7 +15,7 @@ export function SettingsTab({ settings, onSettingsChange }: SettingsTabProps) {
   const checkBackendHealth = async () => {
     setIsCheckingHealth(true);
     try {
-      const response = await fetch('http://localhost:8000/health');
+      const response = await fetch(`${API_BASE_URL}/health`);
       const healthy = response.ok;
       onSettingsChange({ ...settings, backendHealthy: healthy });
     } catch (error) {
@@ -173,7 +175,7 @@ export function SettingsTab({ settings, onSettingsChange }: SettingsTabProps) {
                   {settings.demoMode 
                     ? 'Demo mode active' 
                     : settings.backendHealthy 
-                      ? 'Connected to localhost:8000' 
+                      ? 'Connected'
                       : 'Backend unavailable'
                   }
                 </p>
@@ -210,7 +212,7 @@ export function SettingsTab({ settings, onSettingsChange }: SettingsTabProps) {
           </div>
           <div className="flex justify-between">
             <span>API Endpoint:</span>
-            <span>{settings.demoMode ? 'Mock Service' : 'localhost:8000'}</span>
+            <span>{settings.demoMode ? 'Mock Service' : API_BASE_URL}</span>
           </div>
         </div>
       </div>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,6 +1,6 @@
 import { Document, Session, StreamChunk } from '../types';
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 
 class ApiService {
   private sessionId: string | null = null;


### PR DESCRIPTION
## Summary
- fix backend build context and requirements path
- point frontend API services to `/api`
- display configured API endpoint in settings tab
- update docs with new API base URL

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6847ec7d52a0832f933f3ba7ee73c666