### PR TITLE
Update Ollama service command & healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,17 +33,17 @@ services:
       - "11434:11434"
     volumes:
       - ollama_models:/root/.ollama
-    command: ["ollama", "serve"]
+    command: ["serve"]
     deploy:
       resources:
         reservations:
           devices:
             - capabilities: ["gpu"]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://ollama:11434/api/tags"]
-      interval: 10s
+      test: ["CMD","curl","-f","http://localhost:11434/api/tags"]
+      interval: 30s
       timeout: 5s
-      retries: 5
+      retries: 3
 
   backend:
     build:


### PR DESCRIPTION
## Summary
- update `docker-compose.yml` Ollama service command to run the default `serve`
- update healthcheck to query localhost and adjust timings

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_6847f9244930832fb68f3ee334ce0729