### PR TITLE
Add Postgres volume version guard

### DIFF
--- a/backend/scripts/check_pg_version.sh
+++ b/backend/scripts/check_pg_version.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+PGDATA=/var/lib/postgresql/data
+EXPECTED=16
+if [ -f "$PGDATA/PG_VERSION" ]; then
+  ACTUAL=$(cat $PGDATA/PG_VERSION)
+  if [ "$ACTUAL" != "$EXPECTED" ]; then
+    echo "Incompatible PG_VERSION $ACTUAL – wiping volume"
+    rm -rf $PGDATA/*
+  fi
+fi
+exec "$@"
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,13 @@ version: '3.8'
 services:
   postgres:
     image: postgres:16-alpine
+    entrypoint: ["/bin/bash","/docker-entrypoint-initdb.d/check_pg_version.sh"]
     environment:
       POSTGRES_USER: sapid
       POSTGRES_PASSWORD: sapid
       POSTGRES_DB: sapid
     volumes:
+      - ./backend/scripts/check_pg_version.sh:/docker-entrypoint-initdb.d/check_pg_version.sh:ro
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]


### PR DESCRIPTION
## Summary
- add `backend/scripts/check_pg_version.sh` to wipe incompatible PGDATA
- mount version check script in Postgres container via `docker-compose.yml`

## Testing
- `pip install -r backend/requirements.txt`
- `PYTHONPATH=backend pytest -q` *(fails: Could not connect to a Chroma server)*

------
https://chatgpt.com/codex/tasks/task_e_684800b0ec18832f8c2a06480605b4ad