### PR TITLE
Dockerize frontend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,15 +67,16 @@ services:
       - ./backend:/app
       - ./frontend:/frontend
 
-  nginx:
-    image: nginx:alpine
-    depends_on:
-      - backend
-    volumes:
-      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
-      - ./frontend/dist:/usr/share/nginx/html:ro
+  frontend:
+    build: ./frontend
+    depends_on: [backend]
     ports:
       - "3000:80"
+    healthcheck:
+      test: ["CMD","curl","-f","http://localhost/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
 
   frontend-build:
     image: node:20-alpine

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY . .
+RUN npm ci && npm run build
+
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx","-g","daemon off;"]


### PR DESCRIPTION
## Summary
- build and serve frontend via multi-stage Dockerfile
- remove standalone nginx service and use new frontend service instead

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_6848019d2d30832f862cc12fa551785d