### PR TITLE
Update deploy workflow to pull frontend

### DIFF
--- a/.github/workflows/deploy-gpu.yml
+++ b/.github/workflows/deploy-gpu.yml
@@ -28,8 +28,8 @@ jobs:
         run: |
           ssh ${{ secrets.TARGET_USER }}@${{ secrets.TARGET_HOST }} <<'EOF'
             cd ~/sapid
-            docker compose pull
-            docker compose up -d --build
+            docker compose pull frontend
+            docker compose up -d --build frontend
           EOF
 
       # 4) Wait for backend health


### PR DESCRIPTION
## Summary
- pull frontend image in the GPU deploy workflow
- start only the frontend service when deploying

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: httpx)*

------
https://chatgpt.com/codex/tasks/task_e_684803c50df8832fb71c9abc5820cd08