### PR TITLE
Fix backend package imports and postgres init

### DIFF
--- a/backend/api/chat.py
+++ b/backend/api/chat.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 
 from core.llm import LLM
 from core.rag import RAG
-from ..core import db
+from core import db
 from ..external.incident_api import IncidentAPI
 
 ollama_url = os.getenv("OLLAMA_URL", "http://localhost:11434")

--- a/backend/api/conversations.py
+++ b/backend/api/conversations.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Response
 from pydantic import BaseModel
 
-from ..core import db
+from core import db
 
 router = APIRouter()
 

--- a/backend/api/forms.py
+++ b/backend/api/forms.py
@@ -2,7 +2,7 @@ import json
 from pydantic import BaseModel
 from fastapi import APIRouter
 
-from ..core import db
+from core import db
 
 router = APIRouter()
 

--- a/backend/api/sessions.py
+++ b/backend/api/sessions.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from fastapi import APIRouter, Response
 
-from ..core import db
+from core import db
 
 router = APIRouter()
 

--- a/backend/api/upload.py
+++ b/backend/api/upload.py
@@ -7,7 +7,7 @@ from fastapi.responses import FileResponse
 
 from core.llm import LLM
 from core.rag import RAG
-from ..core import db
+from core import db
 
 
 ollama_url = os.getenv("OLLAMA_URL", "http://localhost:11434")

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -17,7 +17,7 @@ async def test_chat_flow(tmp_path, monkeypatch):
     os.environ['POSTGRES_URL'] = f"sqlite:///{tmp_path}/test.db"
 
 
-    import backend.core.rag as rag_module
+    import core.rag as rag_module
 
     class DummyCollection:
         def add(self, *args, **kwargs):
@@ -32,7 +32,7 @@ async def test_chat_flow(tmp_path, monkeypatch):
 
     monkeypatch.setattr(rag_module, "chromadb", type("x", (), {"HttpClient": lambda *a, **k: DummyClient()})())
 
-    import backend.core.db as db
+    import core.db as db
     import backend.api as backend_api
     import backend.api.chat as chat
     import backend.api.upload as upload

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -11,7 +11,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 async def test_endpoints(tmp_path, monkeypatch):
     os.environ['POSTGRES_URL'] = f"sqlite:///{tmp_path}/db.db"
 
-    import backend.core.rag as rag_module
+    import core.rag as rag_module
 
     class DummyCollection:
         def add(self, *args, **kwargs):
@@ -25,7 +25,7 @@ async def test_endpoints(tmp_path, monkeypatch):
 
     monkeypatch.setattr(rag_module, "chromadb", type("x", (), {"HttpClient": lambda *a, **k: DummyClient()})())
 
-    import backend.core.db as db
+    import core.db as db
     import backend.api as backend_api
     import backend.api.chat as chat
     import backend.api.upload as upload

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ version: '3.8'
 services:
   postgres:
     image: postgres:16-alpine
-    entrypoint: ["/bin/bash","/docker-entrypoint-initdb.d/check_pg_version.sh"]
     environment:
       POSTGRES_USER: sapid
       POSTGRES_PASSWORD: sapid


### PR DESCRIPTION
## Summary
- ensure API uses absolute imports for DB module
- let Postgres container run official entrypoint instead of custom script
- update tests to import the same modules as the API

## Testing
- `PYTHONPATH=backend pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848192a377c832f9fab9a76a5f66219