### PR TITLE
Fix frontend nginx routing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,8 @@ services:
     depends_on: [backend]
     ports:
       - "3000:80"
+    volumes:
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
     healthcheck:
       test: ["CMD","curl","-f","http://localhost/"]
       interval: 30s


### PR DESCRIPTION
## Summary
- mount custom nginx config for frontend via docker-compose

## Testing
- `PYTHONPATH=backend pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68483dd54cc8832fbc21a206567e36eb