### PR TITLE
Remove semicolon and fix lint

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -13,7 +13,11 @@ export interface ChatResponse {
 
 const BASE = import.meta.env.VITE_API_BASE || '/api';
 
-export function chat(sessionId: string, text: string, onMessage: (data: any) => void): Promise<void> {
+export function chat(
+  sessionId: string,
+  text: string,
+  onMessage: (data: unknown) => void,
+): Promise<void> {
   return new Promise((resolve, reject) => {
     const es = new EventSource(`${BASE}/chat?session_id=${sessionId}&message=${encodeURIComponent(text)}&user=user`);
     es.onmessage = (event) => {

--- a/frontend/src/api/apiService.ts
+++ b/frontend/src/api/apiService.ts
@@ -1,4 +1,4 @@
-import { Document, Message, Session, Conversation, StreamChunk } from '../types';
+import { Document, Message, Session, Conversation, StreamChunk } from '../types'
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 


### PR DESCRIPTION
## Summary
- clean up import in apiService
- remove `any` usage in `chat`
- run eslint to confirm lint passes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6848dbe9a980832f84ab2151062ddc9d