### PR TITLE
Add conversation title field

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ model on first run if it's not already installed.
 - `DELETE /upload/documents/{doc_id}` – Remove a document
 - `POST /sessions/` – Create a chat session
 - `DELETE /sessions/{session_id}` – Delete a session
-- `POST /conversations/` – Create a conversation
+- `POST /conversations/` – Create a conversation (optional `title`)
 - `GET /conversations` – List conversations (`session_id` optional)
 - `DELETE /conversations/{conversation_id}` – Delete a conversation
 - `GET /conversations/{conversation_id}/messages` – Conversation history

--- a/backend/alembic/versions/0004_conversation_title.py
+++ b/backend/alembic/versions/0004_conversation_title.py
@@ -1,0 +1,17 @@
+"""add conversation title column"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0004"
+down_revision = "0003"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("conversation", sa.Column("title", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("conversation", "title")

--- a/backend/api/conversations.py
+++ b/backend/api/conversations.py
@@ -8,19 +8,30 @@ router = APIRouter()
 
 class ConversationIn(BaseModel):
     session_id: int
+    title: str | None = None
 
 
 @router.post("/")
 def create_conversation(payload: ConversationIn) -> dict:
-    conv = db.create_conversation(payload.session_id)
-    return {"id": conv.id, "session_id": conv.session_id, "created_at": conv.created_at}
+    conv = db.create_conversation(payload.session_id, title=payload.title)
+    return {
+        "id": conv.id,
+        "session_id": conv.session_id,
+        "title": conv.title,
+        "created_at": conv.created_at,
+    }
 
 
 @router.get("/")
 def list_conversations(session_id: int | None = None) -> list[dict]:
     conversations = db.list_conversations(session_id)
     return [
-        {"id": c.id, "session_id": c.session_id, "created_at": c.created_at}
+        {
+            "id": c.id,
+            "session_id": c.session_id,
+            "title": c.title,
+            "created_at": c.created_at,
+        }
         for c in conversations
     ]
 

--- a/backend/core/db.py
+++ b/backend/core/db.py
@@ -28,6 +28,7 @@ class Conversation(SQLModel, table=True):
 
     id: Optional[int] = Field(default=None, primary_key=True)
     session_id: int = Field(foreign_key="chat_session.id")
+    title: Optional[str] = Field(default=None, nullable=True)
     created_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
 
 
@@ -112,10 +113,10 @@ def delete_session(session_id: int) -> None:
 
 
 
-def create_conversation(session_id: int) -> Conversation:
+def create_conversation(session_id: int, title: Optional[str] = None) -> Conversation:
     """Create a new conversation for a session."""
     with get_session() as session:
-        conv = Conversation(session_id=session_id)
+        conv = Conversation(session_id=session_id, title=title)
         session.add(conv)
         session.commit()
         session.refresh(conv)

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -51,9 +51,13 @@ async def test_endpoints(tmp_path, monkeypatch):
         session_id = sess.json()['id']
 
         # create conversation
-        conv = await client.post('/conversations/', json={'session_id': session_id})
+        conv = await client.post(
+            '/conversations/', json={'session_id': session_id, 'title': 'Test'}
+        )
         assert conv.status_code == 200
-        conv_id = conv.json()['id']
+        conv_body = conv.json()
+        assert conv_body['title'] == 'Test'
+        conv_id = conv_body['id']
 
         # upload via generic endpoint
         pdf_path = 'frontend/public/demo/financial-report.pdf'

--- a/frontend/src/api/apiService.ts
+++ b/frontend/src/api/apiService.ts
@@ -41,7 +41,7 @@ class ApiService {
     this.sessionId = null;
   }
 
-  async createConversation(title: string): Promise<Conversation> {
+  async createConversation(title?: string): Promise<Conversation> {
     if (!this.sessionId) {
       throw new Error('No active session');
     }

--- a/frontend/src/api/endpoints.md
+++ b/frontend/src/api/endpoints.md
@@ -96,7 +96,7 @@ Deletes the specified document.
 ### Create Conversation
 **POST** `/conversations`
 
-**Body:**
+**Body:** (`title` optional)
 ```json
 {
   "session_id": "session_uuid",

--- a/frontend/src/demo/demoService.ts
+++ b/frontend/src/demo/demoService.ts
@@ -22,7 +22,7 @@ class DemoService {
     // Demo cleanup
   }
 
-  async createConversation(title: string): Promise<Conversation> {
+  async createConversation(title?: string): Promise<Conversation> {
     const newConv: Conversation = {
       id: 'conv-' + Date.now(),
       title,

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -28,7 +28,7 @@ export interface Document {
 
 export interface Conversation {
   id: string;
-  title: string;
+  title?: string;
   createdAt: Date;
   lastMessage?: string;
 }


### PR DESCRIPTION
## Summary
- add optional `title` column to Conversation model
- allow passing `title` when creating a conversation
- document new field in README and API docs
- update DB migration and frontend types
- adjust endpoint and tests for new title

## Testing
- `PYTHONPATH=backend pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848ed1a3d40832f8003838d7b2f597f